### PR TITLE
Support eslint-disable-next-line

### DIFF
--- a/lib/introspector.js
+++ b/lib/introspector.js
@@ -35,7 +35,9 @@ const parseComments = (fn, text, start) => {
     comments.unshift(line.slice(3));
   }
   return comments.map(line => line.trimRight())
-    .filter(line => line.length !== 0);
+    .filter(line =>
+      line.length !== 0 && !line.startsWith('eslint-disable-next-line')
+    );
 };
 
 const isNamedLine = line => NAMED_LINES.find(s => line.startsWith(s));


### PR DESCRIPTION
Some functions of class methods may not use arguments and have `eslint-disable-next-line` because of this. An example can be found [here](https://github.com/metarhia/globalstorage/blob/master/lib/provider.js).

/cc @lundibundi @belochub @nechaido.