### PR TITLE
Fix extra empty line after arguments

### DIFF
--- a/lib/generator.js
+++ b/lib/generator.js
@@ -126,6 +126,7 @@ const generateParameters = (parameters, customTypes, usedTypes) => {
       parameter.offset - CODE_PARAMS_OFFSET
     ));
   }
+  if (buf.length !== 0) buf.push('');
   return buf;
 };
 
@@ -148,7 +149,8 @@ const generateReturns = (comments, customTypes, usedTypes) => {
   );
 
   res = generateParameters(comment.parameters, customTypes, usedTypes);
-  return [line, ...res, ''];
+  if (res.length === 0) return [line, ''];
+  else return [line, ...res];
 };
 
 const generateRest = (comments, customTypes, usedTypes) => {
@@ -201,7 +203,6 @@ const generateMd = (inventory, options = {}) => {
       buf.push(...generateParameters(
         signature.parameters, options.customTypes, usedTypes
       ));
-      buf.push('');
       buf.push(...generateReturns(
         signature.comments, options.customTypes, usedTypes
       ));

--- a/test/example.md
+++ b/test/example.md
@@ -66,7 +66,6 @@ _Result:_
 
 #### ExampleClass()
 
-
 ExampleClass description
 
 
@@ -93,7 +92,6 @@ method1 description
 
 
 #### PrototypeClass()
-
 
 PrototypeClass description and PrototypeClass constructor description
 


### PR DESCRIPTION
Empty lines after arguments will be removed as suggested in [comment](https://github.com/metarhia/common/pull/242#discussion_r253026506).
/cc @lundibundi @belochub @nechaido 