### PR TITLE
Fix cli arguments priority

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -61,9 +61,9 @@ const getConfig = args => {
   }
 
   const config = {
-    header: cfg.header || args.header || '',
-    footer: cfg.footer || args.footer || '',
-    removeInterface: cfg.removeInterface || args.removeInterface || false,
+    header: args.header || cfg.header || '',
+    footer: args.footer || cfg.footer || '',
+    removeInterface: args.removeInterface || cfg.removeInterface || false,
     files: common.merge(args._, cfg.files || []),
     customLinks: [],
     outputDir: args.outputDir,


### PR DESCRIPTION
Cli options should have a higher priority than a config file.