### PR TITLE
Fix array type parsing

### DIFF
--- a/lib/introspector.js
+++ b/lib/introspector.js
@@ -73,7 +73,7 @@ const splitComments = lines => {
 
 const parseTypes = rest => {
   const regex = new RegExp(/<[\w.]+(\[])?>/);
-  const regexArr = new RegExp(/\[(<[\w.]+>,\s+)+<[\w.]+>]/);
+  const regexArr = new RegExp(/\[ ?<[\w.]+(\[])?>(, ?<[\w.]+(\[])?>)* ?]/);
   let comment = rest;
   let type = '';
 


### PR DESCRIPTION
Previously, this kind of type would not be parsed correctly: `[ <string[]>, <number[]> ]`. This will also allow spaces to be optional.
/cc @lundibundi @belochub @nechaido 