### PR TITLE
Allow specifying headers level

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -108,12 +108,7 @@ const loadFiles = files => {
   return result;
 };
 
-const select = (...args) => {
-  for (const arg of args) {
-    if (arg !== undefined) return arg;
-  }
-  return undefined;
-};
+const select = (...args) => args.find(a => a !== undefined);
 
 const mergeConfigs = (args, cfg, defaultCfg) => {
   const result = {};

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -34,6 +34,30 @@ const args = yargs
     type: 'number',
     describe: 'minimal header level',
   })
+  .option('interface-level', {
+    type: 'number',
+    describe: 'Set interface header level',
+  })
+  .option('function-level', {
+    type: 'number',
+    describe: 'Set top-level functions header level',
+  })
+  .option('class-level', {
+    type: 'number',
+    describe: 'Set class header level',
+  })
+  .option('method-level', {
+    type: 'number',
+    describe: 'Set class methods header level',
+  })
+  .option('static-method-level', {
+    type: 'number',
+    describe: 'Set class static methods header level',
+  })
+  .option('property-level', {
+    type: 'number',
+    describe: 'Set properties header level',
+  })
   .option('write-to-stdout', {
     alias: 'o',
     type: 'boolean',
@@ -84,6 +108,24 @@ const loadFiles = files => {
   return result;
 };
 
+const select = (...args) => {
+  for (const arg of args) {
+    if (arg !== undefined) return arg;
+  }
+  return undefined;
+};
+
+const mergeConfigs = (args, cfg, defaultCfg) => {
+  const result = {};
+  Object.entries(defaultCfg).forEach(
+    ([key, defaultVal]) =>
+      (result[key] = Array.isArray(defaultVal)
+        ? common.merge(args[key] || [], cfg.files || [], defaultVal)
+        : select(args[key], cfg[key], defaultVal))
+  );
+  return result;
+};
+
 const getConfig = args => {
   let cfg = {};
   if (Array.isArray(args.config)) args.config = args.config.pop();
@@ -94,12 +136,23 @@ const getConfig = args => {
     }
   }
 
+  const level = args.minHeaderLevel || cfg.minHeaderLevel || 1;
+  const defaultConfig = {
+    header: '',
+    footer: '',
+    files: [],
+    removeInterface: false,
+    interfaceLevel: level,
+    functionLevel: level + 1,
+    classLevel: level + 1,
+    methodLevel: level + 2,
+    staticMethodLevel: level + 2,
+    propertyLevel: level + 2,
+  };
+
+  args.files = args._;
   const config = {
-    header: args.header || cfg.header || '',
-    footer: args.footer || cfg.footer || '',
-    removeInterface: args.removeInterface || cfg.removeInterface || false,
-    minHeaderLevel: args.minHeaderLevel || cfg.minHeaderLevel || 1,
-    files: loadFiles(common.merge(args._, cfg.files || [])),
+    ...mergeConfigs(args, cfg, defaultConfig),
     customLinks: [],
     outputDir: args.outputDir,
     outputFile: args.outputFile,
@@ -115,13 +168,11 @@ const getConfig = args => {
     config.footer += fs.readFileSync(footerFile, 'utf8');
   }
 
-  config.files = config.files.map(file => path.resolve(file));
+  config.files = loadFiles(config.files).map(file => path.resolve(file));
 
   if (cfg.customLinks) {
-    config.customTypes = Object.getOwnPropertyNames(cfg.customLinks);
-    for (const type in cfg.customLinks) {
-      config.customLinks.push([type, cfg.customLinks[type]]);
-    }
+    config.customTypes = Object.keys(cfg.customLinks);
+    config.customLinks = Object.entries(cfg.customLinks);
   }
 
   if (args.outputFile || args.outputDir) {

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -267,9 +267,8 @@ const generateMd = (inventory, options = {}) => {
   if (!options.customTypes) options.customTypes = [];
   if (options.header) buf.push(options.header);
   for (const [name, methods] of inventory) {
-    const level = options.minHeaderLevel;
     if (!options.removeInterface) {
-      buf.push(headerify(`Interface: ${name}\n`, level));
+      buf.push(headerify(`Interface: ${name}\n`, options.interfaceLevel));
     }
     for (const [method, signature] of methods) {
       let args = signature.parameters
@@ -300,7 +299,7 @@ const generateMd = (inventory, options = {}) => {
       }
       const asyncPrefix = signature.isAsync ? 'async ' : '';
       if (signature.isClass) {
-        let header = headerify(`class ${method}`, level + 1);
+        let header = headerify(`class ${method}`, options.classLevel);
         const parent = signature.parentClass;
         if (parent) {
           if (ALL_TYPES.has(parent) || options.customTypes.includes(parent)) {
@@ -311,13 +310,26 @@ const generateMd = (inventory, options = {}) => {
           }
         }
         buf.push(header, '');
-      } else if (method.indexOf('.') === -1) {
+      } else if (method.indexOf('.prototype.') !== -1) {
         buf.push(
-          headerify(`${asyncPrefix}${method}(${args.join(', ')})\n`, level + 1)
+          headerify(
+            `${asyncPrefix}${method}(${args.join(', ')})\n`,
+            options.methodLevel
+          )
+        );
+      } else if (method.indexOf('.') !== -1) {
+        buf.push(
+          headerify(
+            `${asyncPrefix}${method}(${args.join(', ')})\n`,
+            options.staticMethodLevel
+          )
         );
       } else {
         buf.push(
-          headerify(`${asyncPrefix}${method}(${args.join(', ')})\n`, level + 2)
+          headerify(
+            `${asyncPrefix}${method}(${args.join(', ')})\n`,
+            options.functionLevel
+          )
         );
       }
       buf.push(
@@ -360,7 +372,7 @@ const generateMd = (inventory, options = {}) => {
           signature.comments,
           options.customTypes,
           usedTypes,
-          level + 2
+          options.propertyLevel
         )
       );
     }


### PR DESCRIPTION
Based on https://github.com/metarhia/metasync/pull/400#pullrequestreview-227691025.

~~This will allow methods header level to be the same as classes and top-level functions.~~
Headers level for interface name, top-level classes, class methods, class static methods, properties can be specified individually via cli or in the config file. The default value is based on `minHeaderLevel` option.

/cc @lundibundi @belochub @nechaido 