### PR TITLE
Support custom comments links

### DIFF
--- a/lib/generator.js
+++ b/lib/generator.js
@@ -143,7 +143,15 @@ const wrapComment = (comment, customTypes, usedTypes) =>
     .trimLeft()
     .replace(/<[\w.]+(\[])?>/g, type =>
       wrapType(type.slice(1, -1), customTypes, usedTypes)
-    );
+    )
+    .replace(/`{[\w.\s]+(\(\))?}`/, link => {
+      link = link.slice(2, -2);
+      if (customTypes.includes(link)) {
+        usedTypes.add(link);
+        return '[`' + link + '`][' + link.toLowerCase() + ']';
+      }
+      return '`' + link + '`';
+    });
 
 const generateParameters = (parameters, customTypes, usedTypes) => {
   const buf = [];

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "doc": "./bin/cli.js",
     "lint": "eslint . && prettier -c \"**/*.js\" \"**/*.json\" \"**/*.md\" \".*rc\" \"**/*.yml\"",
     "fmt": "prettier --write \"**/*.js\" \"**/*.json\" \"**/*.md\" \".*rc\" \"**/*.yml\"",
-    "test": "npm run -s lint && ./bin/cli.js --no-config -d test/ test/example.js"
+    "test": "npm run -s lint && ./bin/cli.js -c test/testConfig.json"
   },
   "files": [
     "lib/",

--- a/test/example.js
+++ b/test/example.js
@@ -129,7 +129,7 @@ const undocumentedDestructureFn = (
 const undocumentedDefaultFn = (arg1, arg2 = 'hello, world') => {};
 
 // Example of links usage
-// To create a link the following format should be used: `{metadoc}`.
+// To create a link the following format should be used: `{meta doc}`.
 // Links can have whitespace characters.
 //   link <string> links can be also used across all comments and links names
 //       can have parentheses at the end like `{introspect()}`.

--- a/test/example.js
+++ b/test/example.js
@@ -128,6 +128,13 @@ const undocumentedDestructureFn = (
 
 const undocumentedDefaultFn = (arg1, arg2 = 'hello, world') => {};
 
+// Example of links usage
+// To create a link the following format should be used: `{metadoc}`.
+// Links can have whitespace characters.
+//   link <string> links can be also used across all comments and links names
+//       can have parentheses at the end like `{introspect()}`.
+const linksExample = link => console.log('Link:', link);
+
 // Call async function
 //   fn <Function>
 //     a <boolean>
@@ -262,7 +269,7 @@ module.exports = {
   undocumentedArgumentFunction,
   undocumentedDestructureFn,
   undocumentedDefaultFn,
-
+  linksExample,
   callAsyncFunction,
   ExampleClass,
   AnotherClass,

--- a/test/example.md
+++ b/test/example.md
@@ -134,6 +134,17 @@ Async functions are supported
 
 ## undocumentedDefaultFn(arg1, arg2 = 'hello, world')
 
+## linksExample(link)
+
+- `link`: [`<string>`][string] links can be also used across all comments and
+  links names can have parentheses at the end like
+  [`introspect()`][introspect()].
+
+Example of links usage
+
+To create a link the following format should be used: `metadoc`. Links can have
+whitespace characters.
+
 ## callAsyncFunction(fn)
 
 - `fn`: [`<Function>`][function]
@@ -234,6 +245,7 @@ PrototypeClass description and PrototypeClass constructor description
 
 method1 description
 
+[introspect()]: https://github.com/metarhia/metadoc#introspectnamespace-text
 [object]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object
 [date]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date
 [function]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function

--- a/test/example.md
+++ b/test/example.md
@@ -142,8 +142,8 @@ Async functions are supported
 
 Example of links usage
 
-To create a link the following format should be used: `metadoc`. Links can have
-whitespace characters.
+To create a link the following format should be used: [`meta doc`][meta doc].
+Links can have whitespace characters.
 
 ## callAsyncFunction(fn)
 
@@ -245,6 +245,7 @@ PrototypeClass description and PrototypeClass constructor description
 
 method1 description
 
+[meta doc]: https://github.com/metarhia/metadoc
 [introspect()]: https://github.com/metarhia/metadoc#introspectnamespace-text
 [object]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object
 [date]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date

--- a/test/testConfig.json
+++ b/test/testConfig.json
@@ -1,0 +1,8 @@
+{
+  "files": ["test/example.js"],
+  "customLinks": {
+    "meta doc": "https://github.com/metarhia/metadoc",
+    "introspect()": "https://github.com/metarhia/metadoc#introspectnamespace-text"
+  },
+  "outputDir": "test/"
+}


### PR DESCRIPTION
Custom links in comments can be specified. For example,
```js
// Some code with a link `{name}` or link to `{functionName()}`.
```
will result in
```md
Some code with a link [`name`][name] or link to [`functionName()`][functionName()].

...

[name]: https://example.com/link/to/name
[functionName()]: https://example.com/link/to/functionName
```
Links can be specified via `customLinks` in `.metadocrc`.