### PR TITLE
Add support for more types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,23 @@ and this project adheres to
 ### Added
 
 - Support for functions in nested objects.
+- Support for the following types:
+  - `Proxy`
+  - `URIError`
+  - `Intl.Collator`
+  - `Intl.DateTimeFormat`
+  - `Intl.ListFormat`
+  - `Intl.NumberFormat`
+  - `Intl.PluralRules`
+  - `Intl.RelativeTimeFormat`
+  - `WebAssembly.Global`
+  - `WebAssembly.Module`
+  - `WebAssembly.Instance`
+  - `WebAssembly.Memory`
+  - `WebAssembly.Table`
+  - `WebAssembly.CompileError`
+  - `WebAssembly.LinkError`
+  - `WebAssembly.RuntimeError`
 
 ## [0.5.3][] - 2019-05-07
 

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -20,10 +20,17 @@ const primitivesLinks = types.PRIMITIVE_TYPES.map(type => [
   `${baseUrl}${primitivesBaseUrl}${common.capitalize(type)}_type`,
 ]);
 
-const globalObjectsLinks = types.OBJECT_TYPES.map(type => [
-  type,
-  `${baseUrl}${globalObjectsBaseUrl}${type}`,
-]);
+const globalObjectsLinks = types.OBJECT_TYPES.map(type => {
+  let link = baseUrl + globalObjectsBaseUrl;
+  if (type.startsWith('Intl.')) {
+    link += type.slice(5);
+  } else if (type.startsWith('WebAssembly.')) {
+    link += `WebAssembly/${type.slice(12)}`;
+  } else {
+    link += type;
+  }
+  return [type, link];
+});
 
 const links = [
   ...globalObjectsLinks,

--- a/lib/types.js
+++ b/lib/types.js
@@ -17,10 +17,13 @@ const OBJECT_TYPES = [
   'RegExp',
   'Promise',
   'DataView',
+  'Proxy',
+
   'Map',
   'WeakMap',
   'Set',
   'WeakSet',
+
   'Array',
   'ArrayBuffer',
   'Int8Array',
@@ -32,12 +35,30 @@ const OBJECT_TYPES = [
   'Uint32Array',
   'Float32Array',
   'Float64Array',
+
   'Error',
   'EvalError',
-  'TypeError',
   'RangeError',
-  'SyntaxError',
   'ReferenceError',
+  'SyntaxError',
+  'TypeError',
+  'URIError',
+
+  'Intl.Collator',
+  'Intl.DateTimeFormat',
+  'Intl.ListFormat',
+  'Intl.NumberFormat',
+  'Intl.PluralRules',
+  'Intl.RelativeTimeFormat',
+
+  'WebAssembly.Global',
+  'WebAssembly.Module',
+  'WebAssembly.Instance',
+  'WebAssembly.Memory',
+  'WebAssembly.Table',
+  'WebAssembly.CompileError',
+  'WebAssembly.LinkError',
+  'WebAssembly.RuntimeError',
 ];
 
 const STANDARD_TYPES = [

--- a/test/example.js
+++ b/test/example.js
@@ -226,23 +226,27 @@ PrototypeClass.prototype.method1 = function(num) {};
 PrototypeClass.method2 = function(num) {};
 
 // List of supported standard types:
-//   `Primitive`
 //   `boolean`,
 //   `null`,
 //   `undefined`,
 //   `number`,
 //   `string`,
 //   `symbol`,
+//
 //   `Object`,
 //   `Date`,
 //   `BigInt`,
 //   `Function`,
 //   `RegExp`,
+//   `Promise`,
 //   `DataView`,
+//   `Proxy`,
+//
 //   `Map`,
 //   `WeakMap`,
 //   `Set`,
 //   `WeakSet`,
+//
 //   `Array`,
 //   `ArrayBuffer`,
 //   `Int8Array`,
@@ -254,12 +258,33 @@ PrototypeClass.method2 = function(num) {};
 //   `Uint32Array`,
 //   `Float32Array`,
 //   `Float64Array`,
+//
 //   `Error`,
 //   `EvalError`,
-//   `TypeError`,
 //   `RangeError`,
-//   `SyntaxError`,
 //   `ReferenceError`,
+//   `SyntaxError`,
+//   `TypeError`,
+//   `URIError`,
+//
+//   `Intl.Collator`,
+//   `Intl.DateTimeFormat`,
+//   `Intl.ListFormat`,
+//   `Intl.NumberFormat`,
+//   `Intl.PluralRules`,
+//   `Intl.RelativeTimeFormat`,
+//
+//   `WebAssembly.Global`,
+//   `WebAssembly.Module`,
+//   `WebAssembly.Instance`,
+//   `WebAssembly.Memory`,
+//   `WebAssembly.Table`,
+//   `WebAssembly.CompileError`,
+//   `WebAssembly.LinkError`,
+//   `WebAssembly.RuntimeError`,
+//
+//   `Primitive`,
+//   `Iterable`,
 //   `this`
 //
 // List of supported non-standard types:


### PR DESCRIPTION
Following types are now supported:
  - [Proxy](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy)
  - [URIError](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/URIError)
  - [Intl.Collator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Collator)
  - [Intl.DateTimeFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat)
  - [Intl.ListFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ListFormat)
  - [Intl.NumberFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/NumberFormat)
  - [Intl.PluralRules](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/PluralRules)
  - [Intl.RelativeTimeFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RelativeTimeFormat)
  - [WebAssembly.Global](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Global)
  - [WebAssembly.Module](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Module)
  - [WebAssembly.Instance](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Instance)
  - [WebAssembly.Memory](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Memory)
  - [WebAssembly.Table](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Table)
  - [WebAssembly.CompileError](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/CompileError)
  - [WebAssembly.LinkError](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/LinkError)
  - [WebAssembly.RuntimeError](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/RuntimeError)

There are also [SharedArrayBuffer](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer) and [InternalError](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/InternalError) but they don't have stable API. [BigInt64Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/BigInt64Array) and [BigUint64Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/BigUint64Array) don't have documentation yet.