### PR TITLE
Fix class constructor handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to
 
 - `eslint-disable` comments processing
 - Support for functions definitions in parameters.
+- Class constructor handling.
 
 ## [0.5.5][] - 2019-05-11
 

--- a/lib/introspector.js
+++ b/lib/introspector.js
@@ -22,7 +22,7 @@ const NOTATION_PRIVATE = '#private';
 //   text - <string>, to be searched in
 //   start - <number>, position to start searching from
 // Returns: <Array>, lines of comments before function
-const parseComments = (fn, text, start) => {
+const parseComments = (fn, text, start = 0) => {
   if (start === -1) return [];
 
   text = text.slice(start);
@@ -222,7 +222,32 @@ const parseRest = lines => {
   return result;
 };
 
+const findBoundsEnd = (str, startStr, endStr, offset = 0) => {
+  const idx = str.indexOf(startStr, offset);
+  if (idx === -1) return -1;
+
+  let level = 0;
+  for (let i = idx; i < str.length; i++) {
+    if (str[i] === startStr) level++;
+    else if (str[i] === endStr) level--;
+    if (level === 0) return i;
+  }
+  return -1;
+};
+
+const findClassConstructor = str => {
+  str = str.slice(str.indexOf('{') + 1, -1);
+  const constructorStart = str.indexOf('constructor(');
+  if (constructorStart === -1) return '';
+  const paramsEnd = findBoundsEnd(str, '(', ')', constructorStart);
+  const bodyEnd = findBoundsEnd(str, '{', '}', paramsEnd);
+  return str.slice(constructorStart, bodyEnd + 1);
+};
+
 const getNativeParams = str => {
+  if (str.startsWith('class')) {
+    str = findClassConstructor(str);
+  }
   if (str.startsWith('async')) str = str.slice(5).trim();
   if (
     !str.startsWith('(') &&
@@ -234,16 +259,11 @@ const getNativeParams = str => {
     if (str.indexOf('(') === -1 || str.indexOf(')') === -1) return str;
   }
 
-  const idx = str.indexOf('(');
-  if (idx === -1) return null;
-
-  let level = 0;
-  for (let i = idx; i < str.length; i++) {
-    if (str[i] === '(') level++;
-    if (str[i] === ')') level--;
-    if (level === 0) return str.slice(idx + 1, i);
-  }
-  return null;
+  const startIdx = str.indexOf('(');
+  if (startIdx === -1) return '';
+  const endIdx = findBoundsEnd(str, '(', ')');
+  if (endIdx === -1) return '';
+  return str.slice(startIdx + 1, endIdx);
 };
 
 // Parse comments related to function
@@ -304,8 +324,7 @@ const parseFunction = (fn, lines) => {
   }
 
   if (typeof fn === 'function') {
-    const nativeParams = getNativeParams(fn.toString());
-    if (nativeParams !== null) sig.nativeParams = nativeParams;
+    sig.nativeParams = getNativeParams(fn.toString());
     if (sig.isClass) {
       const parent = Object.getPrototypeOf(fn.prototype);
       if (parent !== null && parent.constructor.name !== 'Object') {
@@ -375,8 +394,6 @@ const introspect = (namespace, text) => {
         }
       }
 
-      const constructorRegEx = /constructor\((.|\s)*?\)\s*{(.|\s)*}/g;
-
       if (fn.prototype) {
         const props = Object.getOwnPropertyNames(fn.prototype).sort((a, b) => {
           if (b === 'constructor') return 1;
@@ -386,11 +403,11 @@ const introspect = (namespace, text) => {
         for (const prop of props) {
           const propName = `${method}.prototype.${prop}`;
           if (prop === 'constructor') {
-            let sig = parseSignature(
-              constructorRegEx,
-              iface[method].toString(),
-              0
-            );
+            const fnStr = fn.toString();
+            if (!fnStr.startsWith('class')) continue;
+
+            const lines = parseComments(findClassConstructor(fnStr), fnStr);
+            let sig = parseFunction(fn, lines);
             if (
               !sig.title &&
               !sig.description &&

--- a/lib/introspector.js
+++ b/lib/introspector.js
@@ -261,7 +261,7 @@ const getNativeParams = str => {
 
   const startIdx = str.indexOf('(');
   if (startIdx === -1) return '';
-  const endIdx = findBoundsEnd(str, '(', ')');
+  const endIdx = findBoundsEnd(str, '(', ')', startIdx);
   if (endIdx === -1) return '';
   return str.slice(startIdx + 1, endIdx);
 };

--- a/test/example.js
+++ b/test/example.js
@@ -236,6 +236,10 @@ class ExampleClass {
 // Properties:
 //   prop <string>
 class AnotherClass extends ExampleClass {
+  constructor(...args) {
+    super(...args);
+  }
+
   // method4 description
   //   data <string>
   method4(data) {
@@ -259,7 +263,9 @@ class UndocumentedClass extends AnotherClass {
   }
 }
 
-// PrototypeClass description and PrototypeClass constructor description
+// PrototypeClass description description
+// Note that classes on prototypes will not have constructors and will be
+// treated as a regular <function>.
 //   arg1 <Object>
 //   arg2 <string>
 const PrototypeClass = function(arg1, arg2) {};

--- a/test/example.md
+++ b/test/example.md
@@ -239,7 +239,7 @@ method1 description
 
 - [`<string>`][string]
 
-### AnotherClass.prototype.constructor(data)
+### AnotherClass.prototype.constructor(...args)
 
 ### AnotherClass.prototype.method4(data)
 
@@ -247,22 +247,21 @@ method1 description
 
 method4 description
 
-## class PrototypeClass
+## PrototypeClass(arg1, arg2)
 
-PrototypeClass description and PrototypeClass constructor description
+- `arg1`: [`<Object>`][object]
+- `arg2`: [`<string>`][string]
+
+PrototypeClass description description
+
+Note that classes on prototypes will not have constructors and will be treated
+as a regular `<function>`.
 
 ### PrototypeClass.method2(num)
 
 - `num`: [`<number>`][number]
 
 method1 description
-
-### PrototypeClass.prototype.constructor(arg1, arg2)
-
-- `arg1`: [`<Object>`][object]
-- `arg2`: [`<string>`][string]
-
-PrototypeClass description and PrototypeClass constructor description
 
 ### PrototypeClass.prototype.method1(num)
 


### PR DESCRIPTION
Manually search for the class constructor and function arguments instead of using `RegExp`.