### PR TITLE
Do not fail with incorrect padding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to
 
 - Use `main` field from `package.json` as default file if available.
 
+### Fixed
+
+- Handle documentation generation when function parameters have incorrect
+  padding.
+
 ## [0.5.6][] - 2019-05-31
 
 ### Added

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -165,6 +165,13 @@ const generateParameters = (parameters, customTypes, usedTypes) => {
   if (!parameters || !parameters.length) return buf;
 
   for (const parameter of parameters) {
+    if (
+      parameter.offset < CODE_PARAMS_OFFSET ||
+      parameter.offset % CODE_PARAMS_OFFSET !== 0
+    ) {
+      throw new Error(`Incorrect parameter: '${parameter.name}'`);
+    }
+
     const types = common
       .merge(parameter.types, parameter.nonStandardTypes)
       .map(t => wrapType(t, customTypes, usedTypes))
@@ -393,16 +400,21 @@ const generateMd = (inventory, options = {}) => {
           )
         );
       }
-      buf.push(
-        ...generateParameters(
-          signature.parameters,
-          options.customTypes,
-          usedTypes
-        )
-      );
-      buf.push(
-        ...generateReturns(signature.comments, options.customTypes, usedTypes)
-      );
+      try {
+        buf.push(
+          ...generateParameters(
+            signature.parameters,
+            options.customTypes,
+            usedTypes
+          )
+        );
+        buf.push(
+          ...generateReturns(signature.comments, options.customTypes, usedTypes)
+        );
+      } catch (err) {
+        console.error(`'${name}.${method}' generation failed: ${err.message}`);
+        process.exit(1);
+      }
 
       if (signature.title) {
         buf.push(


### PR DESCRIPTION
If parameter documentation in code has incorrect padding, documentation for it will not be generated and an appropriate warning will be displayed.

Closes: https://github.com/metarhia/metadoc/issues/70.