### PR TITLE
Fix package.json to reflect changes in supported Node.js versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "bin/"
   ],
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "devDependencies": {
     "eslint": "^7.1.0",


### PR DESCRIPTION
The support for Node.js 8 was dropped in
3ffcb650a0c224f612ac234b1de93744ce79d3ad.